### PR TITLE
set senderID on participant leave

### DIFF
--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -347,6 +347,7 @@ export function mapMessage(m: TwitterMessage, currentUserID: string, threadParti
         }
         break
       case MessageType.PARTICIPANTS_LEAVE:
+        mapped.senderID = '$thread'
         mapped.text = `${participants.map(p => `{{${p.user_id}}}`).join(', ')} left`
         mapped.action = {
           type: MessageActionType.THREAD_PARTICIPANTS_REMOVED,


### PR DESCRIPTION
Set the sender ID as `$thread` in participant leave message to fix compliance with platform-sdk.

This caused decoding issues in texts-app-ios.