### PR TITLE
map posterImg

### DIFF
--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -222,6 +222,7 @@ const getVideo = (video: any): Attachment => ({
   srcURL: maxBy((video.video_info.variants as any[]).filter(v => v.content_type === 'video/mp4'), 'bitrate')?.url,
   size: pick(video.original_info, ['width', 'height']),
   isVoiceNote: video.audio_only ? true : null,
+  posterImg: video.media_url,
 })
 const getDynamicPhoto = (photo: any): Attachment => ({
   id: photo.id_str,


### PR DESCRIPTION
`video.media_url` or `video.media_url_https` consists of the first frame of the video. Not sure why there's an https version as they both use https.